### PR TITLE
Fix operator precedence in macros by wrapping `exp` in parentheses

### DIFF
--- a/svut/svut_h.sv
+++ b/svut/svut_h.sv
@@ -129,7 +129,7 @@ endfunction
 `define FAIL_IF_NOT(exp, message="") \
     svut_status = 0; \
     svut_msg = create_msg("FAIL_IF_NOT", message); \
-    if (!exp) begin \
+    if (!(exp)) begin \
         `ERROR(svut_msg); \
         svut_status = 1; \
     end
@@ -156,7 +156,7 @@ endfunction
 `define ASSERT(exp, message="") \
     svut_status = 0; \
     svut_msg = create_msg("ASSERT", message); \
-    if (!exp) begin \
+    if (!(exp)) begin \
         `ERROR(svut_msg); \
         svut_status = 1; \
     end


### PR DESCRIPTION
This change ensures correct operator precedence in assertions to prevent logical errors caused by missing parentheses.